### PR TITLE
PM2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function init(
         port: configWithDefaults.websocketPort,
     });
 
-    setupKeyInput(screen.driver);
+    if(process.stdin.setRawMode) setupKeyInput(screen.driver);
 
     app.use(express.static(configWithDefaults.staticDirectory));
     app.listen(configWithDefaults.webPort, () => {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,14 @@ function init(
         port: configWithDefaults.websocketPort,
     });
 
-    if(process.stdin.setRawMode) setupKeyInput(screen.driver);
+    if (process.stdin.setRawMode) {
+        setupKeyInput(screen.driver);
+    } else {
+        process.on('SIGINT', function () {
+            screen.driver.sleep();
+            process.exit();
+        });
+    }
 
     app.use(express.static(configWithDefaults.staticDirectory));
     app.listen(configWithDefaults.webPort, () => {


### PR DESCRIPTION
Check on startup if `process.stdin.setRawMode` is available and load `setupKeyInput()` if so. Otherwise skip loading `setupKeyInput()`.  This provides compatibility with process managers such as PM2.