### PR TITLE
Run puppeteer in headless mode

### DIFF
--- a/packages/core/src/page/getPage.ts
+++ b/packages/core/src/page/getPage.ts
@@ -5,6 +5,7 @@ import { BrowserPage } from './page';
 export async function getPageRpi(width: number, height: number, logger?: Logger) {
     const browser = await puppeteer.launch({
         executablePath: 'chromium-browser',
+        headless: true,
         args: ['--font-render-hinting=slight'],
     });
     const context = await browser.createIncognitoBrowserContext();


### PR DESCRIPTION
This allows epaper.js to run on fully headless devices without the need to set up a virtual frame buffer.

Those devices experience this error:
```
Error: Failed to launch the browser process!
(zenity:1375): Gtk-WARNING **: 17:30:07.547: cannot open display:
```